### PR TITLE
feat(projets): système de pages projet générique (liste + détail SSR)…

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -16,6 +16,12 @@ app.get(
   })
 );
 
+// Redirection 301 permanente : ancienne URL ARMony => canonique (SEO).
+// Doit précéder le handler Angular ci-dessous.
+app.get('/projets/armony', (_req: Request, res: Response) => {
+  res.redirect(301, '/projets/outils-metier/armony');
+});
+
 app.get('*', (req: Request, res: Response) => {
   const engine = new CommonEngine();
   engine

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -37,6 +37,18 @@ export const routes: Routes = [
   },
 
   {
+    path: 'projets/:category',
+    loadComponent: () =>
+      import('./pages/projets/projets-liste/projets-liste.component').then(m => m.ProjetsListeComponent)
+  },
+
+  {
+    path: 'projets/:category/:slug',
+    loadComponent: () =>
+      import('./pages/projets/projet-detail/projet-detail.component').then(m => m.ProjetDetailComponent)
+  },
+
+  {
     path: '404',
     loadComponent: () =>
       import('./pages/not-found/not-found.component').then(m => m.NotFoundComponent),

--- a/src/app/core/projects-data.service.ts
+++ b/src/app/core/projects-data.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@angular/core';
+import projectsData from '../../assets/data/projects.json';
+
+/** Section de contenu riche (page détail). `gallery: true` rend la galerie à cette position. */
+export interface ContentSection {
+  heading: string;
+  paragraphs?: string[];
+  bullets?: string[];
+  gallery?: boolean;
+}
+
+/** Image de galerie de la page détail, avec son alt dédié. */
+export interface GalleryImage {
+  src: string;
+  alt: string;
+}
+
+/** Métadonnées SEO spécifiques (reprend les OG d'une page dédiée existante). */
+export interface ProjectSeo {
+  title: string;
+  description: string;
+  ogTitle?: string;
+  ogImage?: string;
+}
+
+export interface ProjectData {
+  name: string;
+  slug: string;
+  category: 'outils-metier' | 'sites-web';
+  year: string;
+  project: string;
+  role: string;
+  stacks: string;
+  url: string;
+  internalRoute?: string;
+  description: string;
+  images: string[];
+  videos: string[];
+  animationType: string;
+  /** Contenu riche optionnel (étude de cas). Les projets sans `content` gardent le rendu simple. */
+  content?: ContentSection[];
+  /** Galerie de la page détail (séparée de `images`, l'aperçu home). */
+  galleryImages?: GalleryImage[];
+  /** SEO/OG dédiés optionnels. */
+  seo?: ProjectSeo;
+}
+
+/**
+ * Accès aux projets via import direct du JSON (synchrone, donc rendu serveur garanti
+ * sans HttpClient ni garde isPlatformBrowser).
+ */
+@Injectable({ providedIn: 'root' })
+export class ProjectsDataService {
+  private readonly projects = projectsData as ProjectData[];
+
+  getAll(): ProjectData[] {
+    return this.projects;
+  }
+
+  getByCategory(category: string): ProjectData[] {
+    return this.projects.filter((p) => p.category === category);
+  }
+
+  getBySlug(category: string, slug: string): ProjectData | undefined {
+    return this.projects.find((p) => p.category === category && p.slug === slug);
+  }
+}

--- a/src/app/core/seo.service.ts
+++ b/src/app/core/seo.service.ts
@@ -7,6 +7,10 @@ export interface SeoConfig {
   description: string;
   url: string;
   image?: string;
+  /** og:type — laissé tel quel (défaut "website" de l'index.html) si absent. */
+  type?: 'website' | 'article';
+  /** Titre social distinct du <title> ; retombe sur title si absent. */
+  ogTitle?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -20,12 +24,18 @@ export class SeoService {
 
   update(cfg: SeoConfig): void {
 
+    /* Titre social distinct du <title> si fourni, sinon identique */
+    const socialTitle = cfg.ogTitle ?? cfg.title;
+
     /* Title & meta description */
     this.titleSrv.setTitle(cfg.title);
     this.meta.updateTag({ name: 'description', content: cfg.description });
 
     /* Open Graph (Facebook, LinkedIn…) */
-    this.meta.updateTag({ property: 'og:title', content: cfg.title });
+    if (cfg.type) {
+      this.meta.updateTag({ property: 'og:type', content: cfg.type });
+    }
+    this.meta.updateTag({ property: 'og:title', content: socialTitle });
     this.meta.updateTag({ property: 'og:description', content: cfg.description });
     this.meta.updateTag({ property: 'og:url', content: cfg.url });
     if (cfg.image) {
@@ -33,7 +43,7 @@ export class SeoService {
     }
 
     /* Twitter Cards (même contenu que OG) */
-    this.meta.updateTag({ name: 'twitter:title', content: cfg.title });
+    this.meta.updateTag({ name: 'twitter:title', content: socialTitle });
     this.meta.updateTag({ name: 'twitter:description', content: cfg.description });
     if (cfg.image) {
       this.meta.updateTag({ name: 'twitter:image', content: cfg.image });

--- a/src/app/pages/outils-metier/outils-metier.component.html
+++ b/src/app/pages/outils-metier/outils-metier.component.html
@@ -15,9 +15,14 @@
     <p class="hero-intro text-fs-30 text-beige mb-8">
       Je conçois des outils métier sur-mesure pour ces équipes-là. Pas pour automatiser à tout prix, ni pour remplacer ce qui fonctionne déjà bien. Pour celles qui ont identifié précisément ce qui leur coûte du temps chaque semaine, et qui veulent un outil <strong class="text-orange">aligné sur leur métier</strong>, <strong class="text-orange">conçu avec les personnes qui l'utiliseront</strong> vraiment.
     </p>
-    <a class="hero-cta text-fs-30 mt-8" [routerLink]="['/']" fragment="contact">
-      Parler d'un projet →
-    </a>
+    <div class="hero-cta-group mt-8">
+      <a class="hero-cta text-fs-30" [routerLink]="['/']" fragment="contact">
+        Parler d'un projet →
+      </a>
+      <a class="hero-cta text-fs-30" routerLink="/projets/outils-metier">
+        Mes projets →
+      </a>
+    </div>
   </section>
 
   <!-- POUR QUI -->
@@ -53,6 +58,33 @@
       Ce que je conçois
     </h2>
     <app-studio-web [sections]="sections"></app-studio-web>
+  </section>
+
+  <!-- ÉTUDE DE CAS -->
+  <section class="page-etude-cas py-10 py-md-12" aria-labelledby="outils-metier-etude-cas-title">
+    <h2 id="outils-metier-etude-cas-title" class="section-title text-fs-70 text-fs-90-md text-fw-bold text-beige mb-4">
+      Étude de cas
+    </h2>
+    <p class="section-intro text-fs-30 text-beige mb-7 mb-md-9">
+      Un exemple concret d'outil métier conçu sur le terrain, du besoin réel au prototype validé par les équipes.
+    </p>
+
+    <article class="etude-cas-card">
+      <a class="etude-cas-card__media" routerLink="/projets/outils-metier/armony" aria-label="Voir l'étude de cas ARMony">
+        <img src="/assets/img/armony/secto-1.webp"
+             alt="ARMony — écran de sectorisation journalière du prototype"
+             width="1580" height="995" loading="lazy" />
+      </a>
+      <div class="etude-cas-card__body">
+        <h3 class="text-fs-50 text-fs-70-md text-fw-bold mb-3">ARMony</h3>
+        <p class="text-fs-30 text-beige mb-5">
+          Suite d'outils métier pour la régulation médicale : sectorisation journalière, planning mensuel et structuration de données. Prototype validé par les équipes terrain, en phase de validation institutionnelle.
+        </p>
+        <a class="etude-cas-card__link text-fs-20" routerLink="/projets/outils-metier/armony">
+          Voir l'étude de cas →
+        </a>
+      </div>
+    </article>
   </section>
 
   <!-- POURQUOI ME CHOISIR -->

--- a/src/app/pages/outils-metier/outils-metier.component.scss
+++ b/src/app/pages/outils-metier/outils-metier.component.scss
@@ -8,6 +8,7 @@
 
 .page-hero,
 .page-pour-qui,
+.page-etude-cas,
 .page-pourquoi,
 .page-cta {
   padding-left: 5vw;
@@ -49,6 +50,13 @@
     line-height: 1.6;
     opacity: 0.9;
     color: map-get($theme-colors, "beige");
+  }
+
+  .hero-cta-group {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: map-get($spacers, "5");
   }
 
   .hero-cta {
@@ -95,6 +103,80 @@
     p {
       line-height: 1.5;
       margin: 0;
+    }
+  }
+}
+
+.page-etude-cas {
+  border-top: 1.5px solid map-get($theme-colors, "beige");
+
+  .section-intro {
+    max-width: 900px;
+    line-height: 1.6;
+  }
+
+  .etude-cas-card {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    border: 1.5px solid map-get($theme-colors, "beige");
+    border-radius: 4px;
+    overflow: hidden;
+    max-width: 1100px;
+
+    @media (min-width: map-get($breakpoints, "md")) {
+      grid-template-columns: 1.2fr 1fr;
+      align-items: stretch;
+    }
+
+    &__media {
+      display: block;
+      line-height: 0;
+      overflow: hidden;
+
+      img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        transition: transform 0.4s ease;
+      }
+
+      &:hover img,
+      &:focus-visible img {
+        transform: scale(1.03);
+      }
+    }
+
+    &__body {
+      padding: map-get($spacers, "7");
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
+
+      h3 {
+        color: map-get($theme-colors, "orange");
+        line-height: 1.1;
+      }
+
+      p {
+        line-height: 1.6;
+        margin: 0 0 map-get($spacers, "5") 0;
+      }
+    }
+
+    &__link {
+      display: inline-block;
+      color: map-get($theme-colors, "orange");
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      transition: transform 0.3s ease;
+
+      &:hover {
+        transform: translateX(6px);
+      }
     }
   }
 }

--- a/src/app/pages/projets/projet-detail/projet-detail.component.html
+++ b/src/app/pages/projets/projet-detail/projet-detail.component.html
@@ -1,0 +1,99 @@
+<div class="projet-detail-page" *ngIf="project as p">
+
+  <article class="projet-detail">
+
+    <!-- HERO -->
+    <header class="page-hero py-12 py-md-14" aria-labelledby="projet-detail-title">
+      <p class="hero-eyebrow text-fs-20 text-beige mb-4">{{ categoryLabel(p.category) }} · {{ p.year }}</p>
+      <h1 id="projet-detail-title" class="hero-title text-fs-100 text-fs-130-md text-fw-bold text-beige">
+        {{ cleanName(p.name) }}
+      </h1>
+    </header>
+
+    <ng-container *ngIf="p.content && p.content.length; else simple">
+
+      <!-- CONTENU RICHE -->
+      <section *ngFor="let section of p.content" class="projet-section">
+        <h2 *ngIf="section.heading"
+            class="section-title text-fs-70 text-fs-90-md text-fw-bold text-beige">{{ section.heading }}</h2>
+
+        <p *ngFor="let para of (section.paragraphs || [])"
+           class="text-fs-30 text-beige" [innerHTML]="para"></p>
+
+        <ul *ngIf="section.bullets && section.bullets.length">
+          <li *ngFor="let b of section.bullets" class="text-fs-30 text-beige" [innerHTML]="b"></li>
+        </ul>
+
+        <ng-container *ngIf="section.gallery">
+          <ng-container *ngTemplateOutlet="galleryTpl"></ng-container>
+        </ng-container>
+      </section>
+
+      <!-- CTA -->
+      <section class="projet-section projet-cta-section">
+        <p class="projet-cta">
+          <a *ngIf="hasExternalUrl" class="projet-btn text-fs-30"
+             [href]="externalUrl()" target="_blank" rel="noopener noreferrer">Voir le site en ligne</a>
+          <a *ngIf="!hasExternalUrl" class="projet-btn text-fs-30"
+             [href]="bookingUrl" target="_blank" rel="noopener noreferrer">Prendre rendez-vous</a>
+        </p>
+        <p class="projet-signature text-fs-20 text-beige">
+          Luc Jaubert · développeur web freelance · lucjaubert.com
+        </p>
+      </section>
+
+    </ng-container>
+
+    <!-- RENDU SIMPLE (projets sans content) -->
+    <ng-template #simple>
+      <section class="projet-section">
+        <p class="projet-lead text-fs-40 text-fs-50-md text-beige mb-6">{{ p.project }}</p>
+        <p class="text-fs-30 text-beige">{{ p.description }}</p>
+
+        <div class="projet-meta">
+          <div class="projet-meta__block">
+            <p class="projet-meta__label text-fs-20 text-orange mb-2"><strong>Mes missions</strong></p>
+            <p class="text-fs-30 text-beige">{{ p.role }}</p>
+          </div>
+          <div class="projet-meta__block">
+            <p class="projet-meta__label text-fs-20 text-orange mb-2"><strong>Stacks</strong></p>
+            <p class="text-fs-30 text-beige">{{ p.stacks }}</p>
+          </div>
+        </div>
+
+        <p class="projet-cta">
+          <a *ngIf="hasExternalUrl" class="projet-btn text-fs-30"
+             [href]="externalUrl()" target="_blank" rel="noopener noreferrer">Voir le site en ligne</a>
+          <a *ngIf="!hasExternalUrl" class="projet-btn text-fs-30"
+             [href]="bookingUrl" target="_blank" rel="noopener noreferrer">Prendre rendez-vous</a>
+        </p>
+      </section>
+
+      <section class="projet-section projet-gallery-section" *ngIf="galleryItems().length">
+        <h2 class="section-title text-fs-70 text-fs-90-md text-fw-bold text-beige">Aperçu</h2>
+        <ng-container *ngTemplateOutlet="galleryTpl"></ng-container>
+      </section>
+    </ng-template>
+
+  </article>
+
+  <!-- Galerie réutilisable -->
+  <ng-template #galleryTpl>
+    <div class="projet-gallery">
+      <button type="button" class="projet-gallery__item"
+              *ngFor="let item of galleryItems(); let i = index"
+              (click)="openLightbox($event)">
+        <img [src]="'/' + item.src" [alt]="item.alt" [attr.loading]="i === 0 ? 'eager' : 'lazy'" />
+      </button>
+    </div>
+  </ng-template>
+
+  <!-- Lightbox (confort JS, s'attache après hydratation) -->
+  <div *ngIf="lightboxOpen" class="projet-lightbox" role="dialog" aria-modal="true"
+       aria-label="Aperçu agrandi" (click)="closeLightbox()">
+    <button type="button" class="projet-lightbox__close" aria-label="Fermer l'aperçu" (click)="closeLightbox()">×</button>
+    <img class="projet-lightbox__img" [src]="lightboxSrc" [alt]="lightboxAlt" (click)="$event.stopPropagation()" />
+  </div>
+
+  <app-footer></app-footer>
+</div>

--- a/src/app/pages/projets/projet-detail/projet-detail.component.scss
+++ b/src/app/pages/projets/projet-detail/projet-detail.component.scss
@@ -1,0 +1,248 @@
+@import "../../../../styles/_variables.scss";
+
+.projet-detail-page {
+  background-color: map-get($theme-colors, "black");
+  color: map-get($theme-colors, "beige");
+  min-height: 100vh;
+}
+
+.projet-detail {
+  .page-hero,
+  .projet-section {
+    padding-left: 5vw;
+    padding-right: 5vw;
+  }
+}
+
+.page-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border-bottom: 1.5px solid map-get($theme-colors, "beige");
+
+  .hero-eyebrow {
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+
+  .hero-title {
+    line-height: 1;
+    margin: 0;
+    max-width: 1100px;
+    color: map-get($theme-colors, "beige");
+  }
+}
+
+.section-title {
+  display: block;
+  color: map-get($theme-colors, "beige");
+  line-height: 1.1;
+  margin-bottom: map-get($spacers, "6");
+
+  @media (min-width: map-get($breakpoints, "md")) {
+    margin-bottom: map-get($spacers, "8");
+  }
+}
+
+.projet-section {
+  padding-top: map-get($spacers, "8");
+  padding-bottom: map-get($spacers, "8");
+
+  p {
+    line-height: 1.6;
+    max-width: 1000px;
+    margin: 0;
+  }
+
+  p + p {
+    margin-top: map-get($spacers, "5");
+  }
+
+  .projet-lead {
+    line-height: 1.3;
+    max-width: 1000px;
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-width: 1000px;
+    display: flex;
+    flex-direction: column;
+    gap: map-get($spacers, "5");
+  }
+
+  p + ul,
+  ul + p {
+    margin-top: map-get($spacers, "6");
+  }
+
+  li {
+    position: relative;
+    line-height: 1.6;
+    padding-left: map-get($spacers, "6");
+
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0.6em;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: map-get($theme-colors, "orange");
+    }
+  }
+
+  em {
+    font-style: italic;
+  }
+}
+
+// Métadonnées (rendu simple)
+.projet-meta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: map-get($spacers, "6");
+  margin-top: map-get($spacers, "7");
+
+  @media (min-width: map-get($breakpoints, "md")) {
+    grid-template-columns: 1fr 1fr;
+    gap: map-get($spacers, "8");
+  }
+
+  &__block p {
+    margin: 0;
+  }
+
+  &__label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+}
+
+// CTA — espacement généreux pour détacher nettement le bouton du texte au-dessus.
+// Règle UNIQUE : vaut pour tous les projets (Voir le site / Prendre rendez-vous).
+// Sélecteur `.projet-section .projet-cta` (0,2,0) pour battre `.projet-section p { margin: 0 }` (0,1,1).
+.projet-cta-section {
+  padding-top: 0;
+}
+
+.projet-section .projet-cta {
+  margin-top: map-get($spacers, "11");
+
+  .projet-btn {
+    display: inline-block;
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0.7em 1.5em;
+    border-radius: 4px;
+    background-color: map-get($theme-colors, "orange");
+    color: map-get($theme-colors, "black");
+    transition: transform 0.3s ease;
+
+    &:hover {
+      transform: translateX(6px);
+    }
+  }
+}
+
+.projet-signature {
+  opacity: 0.8;
+  margin-top: map-get($spacers, "6");
+}
+
+// Galerie
+.projet-gallery {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: map-get($spacers, "6");
+  margin-top: map-get($spacers, "6");
+  max-width: 1100px;
+
+  @media (min-width: map-get($breakpoints, "md")) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: map-get($spacers, "7");
+  }
+
+  &__item {
+    display: block;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    border: 1.5px solid map-get($theme-colors, "beige");
+    border-radius: 4px;
+    background: transparent;
+    cursor: pointer;
+    overflow: hidden;
+    line-height: 0;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+    img {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+
+    &:hover,
+    &:focus-visible {
+      transform: translateY(-3px);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    }
+
+    &:focus-visible {
+      outline: 2px solid map-get($theme-colors, "orange");
+      outline-offset: 2px;
+    }
+  }
+}
+
+// Lightbox
+.projet-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5vw;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: zoom-out;
+
+  &__img {
+    max-width: 100%;
+    max-height: 90vh;
+    width: auto;
+    height: auto;
+    border-radius: 4px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+    cursor: default;
+  }
+
+  &__close {
+    position: absolute;
+    top: map-get($spacers, "5");
+    right: map-get($spacers, "6");
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    line-height: 1;
+    color: map-get($theme-colors, "beige");
+    background: transparent;
+    border: 1.5px solid map-get($theme-colors, "beige");
+    border-radius: 50%;
+    cursor: pointer;
+    transition: color 0.3s ease, border-color 0.3s ease;
+
+    &:hover,
+    &:focus-visible {
+      color: map-get($theme-colors, "orange");
+      border-color: map-get($theme-colors, "orange");
+    }
+  }
+}

--- a/src/app/pages/projets/projet-detail/projet-detail.component.ts
+++ b/src/app/pages/projets/projet-detail/projet-detail.component.ts
@@ -1,0 +1,126 @@
+import { CommonModule } from '@angular/common';
+import { Component, HostListener, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { FooterComponent } from '../../../shared/components/footer/footer.component';
+import { SeoService } from '../../../core/seo.service';
+import { ProjectsDataService, ProjectData, GalleryImage } from '../../../core/projects-data.service';
+
+@Component({
+  selector: 'app-projet-detail',
+  standalone: true,
+  imports: [CommonModule, RouterModule, FooterComponent],
+  templateUrl: './projet-detail.component.html',
+  styleUrls: ['./projet-detail.component.scss']
+})
+export class ProjetDetailComponent implements OnInit {
+  project?: ProjectData;
+
+  readonly bookingUrl =
+    'https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2noGgcNtZash82WCL0Mkb_q2kBUWt_KSD5kjBf60waEpjl2AH9RKzp51BQ1E6vCRDCPxbR-_sM';
+
+  // Lightbox — confort JS, les <img> restent en dur (rendu SSR).
+  lightboxOpen = false;
+  lightboxSrc = '';
+  lightboxAlt = '';
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private seo: SeoService,
+    private data: ProjectsDataService
+  ) {}
+
+  ngOnInit(): void {
+    // Lecture synchrone des params + données : rendu serveur garanti, aucun garde navigateur.
+    const category = this.route.snapshot.paramMap.get('category') ?? '';
+    const slug = this.route.snapshot.paramMap.get('slug') ?? '';
+    const project = this.data.getBySlug(category, slug);
+
+    if (!project) {
+      this.router.navigateByUrl('/404');
+      return;
+    }
+
+    this.project = project;
+
+    const url = `https://lucjaubert.com/projets/${project.category}/${project.slug}`;
+
+    if (project.seo) {
+      // OG dédiés (ex. ARMony) repris tels quels, url canonique sur la route générique.
+      this.seo.update({
+        title: project.seo.title,
+        description: project.seo.description,
+        url,
+        image: project.seo.ogImage ?? this.firstImageAbsolute(project),
+        type: 'article',
+        ogTitle: project.seo.ogTitle ?? this.cleanName(project.name)
+      });
+    } else {
+      this.seo.update({
+        title: `${this.cleanName(project.name)} — étude de projet | Luc Jaubert`,
+        description: project.description,
+        url,
+        image: this.firstImageAbsolute(project),
+        type: 'article',
+        ogTitle: this.cleanName(project.name)
+      });
+    }
+  }
+
+  private firstImageAbsolute(project: ProjectData): string {
+    const first = project.galleryImages?.[0]?.src ?? project.images?.[0];
+    return first
+      ? `https://lucjaubert.com/${first.replace(/^\//, '')}`
+      : 'https://lucjaubert.com/assets/icons/apple-touch-icon.png';
+  }
+
+  /** Galerie de la page détail : galleryImages si présent, sinon images (avec alt généré). */
+  galleryItems(): GalleryImage[] {
+    if (!this.project) return [];
+    if (this.project.galleryImages?.length) {
+      return this.project.galleryImages;
+    }
+    const name = this.cleanName(this.project.name);
+    return (this.project.images ?? []).map((src, i) => ({
+      src,
+      alt: `${name} — visuel ${i + 1}`
+    }));
+  }
+
+  /** Retire le suffixe " ." final et l'éventuel "(en cours)". */
+  cleanName(name: string): string {
+    return name.replace(' (en cours)', '').replace(/\s*\.\s*$/, '').trim();
+  }
+
+  get hasExternalUrl(): boolean {
+    return !!this.project?.url && this.project.url.trim().length > 0;
+  }
+
+  externalUrl(): string {
+    const url = (this.project?.url ?? '').trim();
+    return /^https?:\/\//i.test(url) ? url : 'https://' + url;
+  }
+
+  categoryLabel(category: string): string {
+    return category === 'outils-metier' ? 'Outils métier' : 'Sites web';
+  }
+
+  openLightbox(event: Event): void {
+    const img = (event.currentTarget as HTMLElement).querySelector('img');
+    if (!img) return;
+    this.lightboxSrc = img.getAttribute('src') ?? '';
+    this.lightboxAlt = img.getAttribute('alt') ?? '';
+    this.lightboxOpen = true;
+  }
+
+  closeLightbox(): void {
+    this.lightboxOpen = false;
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.lightboxOpen) {
+      this.closeLightbox();
+    }
+  }
+}

--- a/src/app/pages/projets/projets-liste/projets-liste.component.html
+++ b/src/app/pages/projets/projets-liste/projets-liste.component.html
@@ -1,0 +1,36 @@
+<div class="projets-liste-page" *ngIf="category">
+
+  <article class="projets-liste">
+
+    <!-- HERO -->
+    <header class="page-hero py-12 py-md-14" aria-labelledby="projets-liste-title">
+      <p class="hero-eyebrow text-fs-20 text-beige mb-4">Projets</p>
+      <h1 id="projets-liste-title" class="hero-title text-fs-100 text-fs-130-md text-fw-bold text-beige">
+        {{ categoryLabel(category) }}
+      </h1>
+    </header>
+
+    <!-- LISTE -->
+    <section class="projets-liste-section py-10 py-md-12" aria-label="Liste des projets">
+      <ul class="projets-grid">
+        <li class="projet-card" *ngFor="let p of projects">
+          <a class="projet-card__link" [routerLink]="['/projets', p.category, p.slug]"
+             [attr.aria-label]="'Voir le projet ' + cleanName(p.name)">
+            <span class="projet-card__media" *ngIf="p.images && p.images.length">
+              <img [src]="'/' + p.images[0]" [alt]="cleanName(p.name)" loading="lazy" />
+            </span>
+            <span class="projet-card__body">
+              <span class="projet-card__year text-fs-20 text-orange">{{ p.year }}</span>
+              <span class="projet-card__name text-fs-50 text-fs-70-md text-fw-bold text-beige">{{ cleanName(p.name) }}</span>
+              <span class="projet-card__excerpt text-fs-30 text-beige">{{ excerpt(p) }}</span>
+              <span class="projet-card__cta text-fs-20">Voir le projet →</span>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </section>
+
+  </article>
+
+  <app-footer></app-footer>
+</div>

--- a/src/app/pages/projets/projets-liste/projets-liste.component.scss
+++ b/src/app/pages/projets/projets-liste/projets-liste.component.scss
@@ -1,0 +1,120 @@
+@import "../../../../styles/_variables.scss";
+
+.projets-liste-page {
+  background-color: map-get($theme-colors, "black");
+  color: map-get($theme-colors, "beige");
+  min-height: 100vh;
+}
+
+.projets-liste {
+  .page-hero,
+  .projets-liste-section {
+    padding-left: 5vw;
+    padding-right: 5vw;
+  }
+}
+
+.page-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border-bottom: 1.5px solid map-get($theme-colors, "beige");
+
+  .hero-eyebrow {
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+
+  .hero-title {
+    line-height: 1;
+    margin: 0;
+    max-width: 1100px;
+    color: map-get($theme-colors, "beige");
+  }
+}
+
+.projets-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: map-get($spacers, "8");
+
+  @media (min-width: map-get($breakpoints, "md")) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: map-get($spacers, "9");
+  }
+}
+
+.projet-card {
+  &__link {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    text-decoration: none;
+    border: 1.5px solid map-get($theme-colors, "beige");
+    border-radius: 4px;
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+    &:hover,
+    &:focus-visible {
+      transform: translateY(-4px);
+      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+    }
+
+    &:focus-visible {
+      outline: 2px solid map-get($theme-colors, "orange");
+      outline-offset: 2px;
+    }
+  }
+
+  &__media {
+    display: block;
+    line-height: 0;
+    overflow: hidden;
+
+    img {
+      display: block;
+      width: 100%;
+      height: auto;
+      aspect-ratio: 16 / 10;
+      object-fit: cover;
+    }
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: map-get($spacers, "3");
+    padding: map-get($spacers, "6");
+  }
+
+  &__year {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+
+  &__name {
+    line-height: 1.1;
+  }
+
+  &__excerpt {
+    line-height: 1.5;
+    opacity: 0.9;
+  }
+
+  &__cta {
+    margin-top: map-get($spacers, "3");
+    color: map-get($theme-colors, "orange");
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    transition: transform 0.3s ease;
+  }
+
+  &__link:hover &__cta {
+    transform: translateX(6px);
+  }
+}

--- a/src/app/pages/projets/projets-liste/projets-liste.component.ts
+++ b/src/app/pages/projets/projets-liste/projets-liste.component.ts
@@ -1,0 +1,61 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { FooterComponent } from '../../../shared/components/footer/footer.component';
+import { SeoService } from '../../../core/seo.service';
+import { ProjectsDataService, ProjectData } from '../../../core/projects-data.service';
+
+const KNOWN_CATEGORIES = ['outils-metier', 'sites-web'];
+
+@Component({
+  selector: 'app-projets-liste',
+  standalone: true,
+  imports: [CommonModule, RouterModule, FooterComponent],
+  templateUrl: './projets-liste.component.html',
+  styleUrls: ['./projets-liste.component.scss']
+})
+export class ProjetsListeComponent implements OnInit {
+  category = '';
+  projects: ProjectData[] = [];
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private seo: SeoService,
+    private data: ProjectsDataService
+  ) {}
+
+  ngOnInit(): void {
+    // Lecture synchrone : rendu serveur garanti, aucun garde navigateur.
+    const category = this.route.snapshot.paramMap.get('category') ?? '';
+
+    if (!KNOWN_CATEGORIES.includes(category)) {
+      this.router.navigateByUrl('/404');
+      return;
+    }
+
+    this.category = category;
+    this.projects = this.data.getByCategory(category);
+
+    const label = this.categoryLabel(category);
+    this.seo.update({
+      title: `${label} — projets | Luc Jaubert`,
+      description: `Projets ${label.toLowerCase()} réalisés par Luc Jaubert, développeur web freelance à Bordeaux.`,
+      url: `https://lucjaubert.com/projets/${category}`,
+      image: 'https://lucjaubert.com/assets/icons/apple-touch-icon.png',
+      type: 'website'
+    });
+  }
+
+  cleanName(name: string): string {
+    return name.replace(' (en cours)', '').replace(/\s*\.\s*$/, '').trim();
+  }
+
+  categoryLabel(category: string): string {
+    return category === 'outils-metier' ? 'Outils métier' : 'Sites web';
+  }
+
+  excerpt(p: ProjectData): string {
+    return p.project || p.description;
+  }
+}

--- a/src/app/pages/sites-web/sites-web.component.html
+++ b/src/app/pages/sites-web/sites-web.component.html
@@ -15,9 +15,14 @@
     <p class="hero-intro text-fs-30 text-beige mb-8">
       Je conçois des <strong class="text-yellow">sites internet sur-mesure</strong> pour ces structures-là. Pas pour les projets qui démarrent de zéro et veulent juste exister en ligne, ni pour ceux qui cherchent le moins-disant. Pour celles qui ont compris qu'un site web n'est pas une dépense de communication mais <strong class="text-yellow">un outil stratégique</strong>, et qui veulent y mettre la matière nécessaire.
     </p>
-    <a class="hero-cta text-fs-30" [routerLink]="['/']" fragment="contact">
-      Parler d'un projet →
-    </a>
+    <div class="hero-cta-group">
+      <a class="hero-cta text-fs-30" [routerLink]="['/']" fragment="contact">
+        Parler d'un projet →
+      </a>
+      <a class="hero-cta text-fs-30" routerLink="/projets/sites-web">
+        Mes projets →
+      </a>
+    </div>
   </section>
 
 

--- a/src/app/pages/sites-web/sites-web.component.scss
+++ b/src/app/pages/sites-web/sites-web.component.scss
@@ -115,6 +115,13 @@
     opacity: 0.9;
   }
 
+  .hero-cta-group {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: map-get($spacers, "5");
+  }
+
   .hero-cta {
     color: map-get($theme-colors, "blue");
     text-decoration: none;

--- a/src/app/pages/sites-web/sites-web.component.ts
+++ b/src/app/pages/sites-web/sites-web.component.ts
@@ -73,6 +73,14 @@ export const PROJETS_RECENTS: ProjetRecent[] = [
     testimonial:
       "J'ai été enchantée de collaborer avec Luc Jaubert pour le développement de mon site web de la Laiterie Burdigala. Il a été pédagogue, disponible et à l'écoute. Le monde de l'informatique n'étant pas mon métier, il a su se faire comprendre et rendre intuitive l'alimentation du site (renseignement des Textes). De plus, ayant mon entreprise et étant prise par de nombreuses urgences, il n'a pas hésité à me relancer, afin de pouvoir terminer dans les temps. Je recommande son travail à 200%, vous pouvez lui faire confiance les yeux fermés.",
     testimonialAuthor: 'Laiterie Burdigala'
+  },
+  {
+    title: "Violette Cruse — décoratrice d'intérieur, hôtellerie & lieux de caractère",
+    url: 'https://www.violettecrusedecoration.fr/',
+    description:
+      "Site vitrine bilingue (français / anglais) pour une décoratrice d'intérieur bordelaise spécialisée dans l'hôtellerie et les lieux de caractère, avec portfolio de projets en France et à l'international. Développement sur-mesure sous Angular 18 SSR et WordPress Headless, avec zoning, maquettes Figma et intégration de la charte graphique.",
+    testimonial: null,
+    testimonialAuthor: null
   }
 ];
 

--- a/src/app/shared/components/contact/contact.component.html
+++ b/src/app/shared/components/contact/contact.component.html
@@ -34,6 +34,17 @@
   <div class="background-contact"></div>
 
   <div class="contact-links mt-5">
+    <p class="contact-item contact-rdv">
+      <a
+        href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2noGgcNtZash82WCL0Mkb_q2kBUWt_KSD5kjBf60waEpjl2AH9RKzp51BQ1E6vCRDCPxbR-_sM"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Réserver un créneau de rendez-vous avec Luc Jaubert"
+      >
+        RESERVER UN CRENEAU
+      </a>
+    </p>
+
     <p class="contact-item contact-email">
       <a href="mailto:lucjaubert.dev&#64;gmail.com" class="email-link" aria-label="Envoyer un email à Luc Jaubert">
         <span class="default-text">EMAIL</span>

--- a/src/app/shared/components/projects/projects.component.html
+++ b/src/app/shared/components/projects/projects.component.html
@@ -23,25 +23,12 @@
               (mouseenter)="onProjectHover(project, $event)"
               (mouseleave)="onProjectOut($event)"
             >
-              <div class="project-item" [class.project-item--wrap]="i === 0">
+              <div class="project-item project-item--wrap">
                 <h5
                   [ngClass]="'offset-' + i"
                   class="mb-0"
                   (mousemove)="onProjectHoverMove($event)"
-                >
-                  {{ project.name.replace(' (en cours)', '') }}
-                  <small *ngIf="project.name.includes('(en cours)')">(en cours)</small>
-
-                  <ng-container *ngIf="i === 0; else yearOutside">
-                    <span class="date date-inline">{{ project.year }}</span>
-                  </ng-container>
-
-                  <ng-template #yearOutside></ng-template>
-                </h5>
-
-                <ng-container *ngIf="i !== 0">
-                  <span [ngClass]="'offset-' + i" class="date">{{ project.year }}</span>
-                </ng-container>
+                >{{ titleHead(project.name) }}<span class="title-tail">{{ titleTail(project.name) }}<small *ngIf="project.name.includes('(en cours)')">&#160;(en cours)</small><span class="date date-inline">&#160;{{ project.year }}</span></span></h5>
               </div>
 
 

--- a/src/app/shared/components/projects/projects.component.scss
+++ b/src/app/shared/components/projects/projects.component.scss
@@ -93,7 +93,13 @@
         display: flex;
         align-items: baseline;
         justify-content: center;
-        white-space: nowrap;
+        white-space: normal;
+        max-width: 100%;
+
+        // Le titre wrappe entre ses mots ; seul « dernier mot + année » reste insécable.
+        .title-tail {
+          white-space: nowrap !important;
+        }
 
         h5,
         .date {
@@ -106,7 +112,7 @@
 
           h5,
           .date {
-            white-space: nowrap;
+            white-space: normal;
             word-break: keep-all;
             text-align: left;
           }

--- a/src/app/shared/components/projects/projects.component.ts
+++ b/src/app/shared/components/projects/projects.component.ts
@@ -14,22 +14,29 @@ import {
 } from '@angular/core';
 import { gsap, CSSPlugin, ScrollTrigger } from 'gsap/all';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { BreakpointObserver } from '@angular/cdk/layout';
+import { ContentSection, GalleryImage, ProjectSeo } from '../../../core/projects-data.service';
 
 gsap.registerPlugin(CSSPlugin, ScrollTrigger);
 
 interface Project {
   name: string;
+  slug: string;
+  category: 'outils-metier' | 'sites-web';
   year: string;
   project: string;
   role: string;
   stacks: string;
   url: string;
+  internalRoute?: string;
   images: string[];
   videos: string[];
   animationType: string;
+  content?: ContentSection[];
+  galleryImages?: GalleryImage[];
+  seo?: ProjectSeo;
   mediaSequence?: { type: 'image' | 'video'; src: string }[];
 }
 
@@ -71,7 +78,8 @@ export class ProjectsComponent implements OnInit, AfterViewInit, OnDestroy {
     private http: HttpClient,
     private cdr: ChangeDetectorRef,
     private breakpointObserver: BreakpointObserver,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -85,7 +93,8 @@ export class ProjectsComponent implements OnInit, AfterViewInit, OnDestroy {
         limagoAnimation: { in: () => this.initProjectAnimation('limago'), out: () => {} },
         maisonAnimation: { in: () => this.initProjectAnimation('maison'), out: () => {} },
         abcAnimation: { in: () => this.initProjectAnimation('abc'), out: () => {} },
-        violetteAnimation: { in: () => this.initProjectAnimation('violette'), out: () => {} }
+        violetteAnimation: { in: () => this.initProjectAnimation('violette'), out: () => {} },
+        armonyAnimation: { in: () => this.initProjectAnimation('armony'), out: () => {} }
       };
 
       this.breakpointObserver.observe(['(min-width: 768px)']).subscribe(state => {
@@ -175,7 +184,40 @@ export class ProjectsComponent implements OnInit, AfterViewInit, OnDestroy {
     return mediaSequence.sort(() => Math.random() - 0.5);
   }
 
+  /**
+   * Découpe le titre pour rendre insécable le couple « dernier mot + année ».
+   * head = tout sauf le dernier mot (wrappe normalement) ; tail = dernier mot + " ." (collé à l'année via .title-tail nowrap).
+   */
+  private splitName(rawName: string): { head: string; tail: string } {
+    const name = rawName.replace(' (en cours)', '').trim();
+    const hasDot = / \.$/.test(name);
+    const base = hasDot ? name.replace(/ \.$/, '') : name;
+    const dot = hasDot ? ' .' : '';
+    const idx = base.lastIndexOf(' ');
+    if (idx === -1) {
+      return { head: '', tail: base + dot };
+    }
+    return { head: base.slice(0, idx), tail: base.slice(idx + 1) + dot };
+  }
+
+  titleHead(rawName: string): string {
+    const head = this.splitName(rawName).head;
+    return head ? head + ' ' : '';
+  }
+
+  titleTail(rawName: string): string {
+    return this.splitName(rawName).tail;
+  }
+
   onProjectContainerClick(index: number): void {
+    const project = this.projects[index];
+
+    // Projet à route interne (ex. ARMony) : navigation SPA, même onglet.
+    if (project?.internalRoute) {
+      this.router.navigate([project.internalRoute]);
+      return;
+    }
+
     if (!this.isDesktop) {
       this.toggleMediaPreview(index);
     } else {

--- a/src/assets/data/projects.json
+++ b/src/assets/data/projects.json
@@ -1,6 +1,122 @@
 [
   {
+    "name": "ARMONY .",
+    "slug": "armony",
+    "category": "outils-metier",
+    "year": "2026",
+    "project": "Suite d'outils métier pour la régulation médicale : sectorisation journalière et planning mensuel",
+    "role": "Analyse du besoin terrain, structuration de données réelles, conception d'outils sur-mesure, co-construction avec les utilisateurs",
+    "stacks": "HTML · SVG · JavaScript · Python (extraction de données)",
+    "url": "",
+    "internalRoute": "/projets/outils-metier/armony",
+    "description": "Prototype d'outils d'aide à la planification (sectorisation, planning mensuel, structuration de données) pour un service de régulation médicale. Validé par les équipes terrain, en phase de validation institutionnelle.",
+    "images": [
+      "assets/img/armony/planning-mensuel.webp",
+      "assets/img/armony/secto-1.webp",
+      "assets/img/armony/competences-samu-33.webp"
+    ],
+    "videos": [],
+    "animationType": "armonyAnimation",
+    "seo": {
+      "title": "ARMony — Étude de cas outils métier (régulation médicale) | Luc Jaubert",
+      "description": "Conception d'une suite d'outils métier pour un service de régulation médicale (SAMU) : sectorisation, planning, structuration de données. Prototype validé terrain, en validation institutionnelle.",
+      "ogTitle": "ARMony — Outils métier pour la régulation médicale",
+      "ogImage": "https://lucjaubert.com/assets/images/og/armony-og.jpg"
+    },
+    "galleryImages": [
+      { "src": "assets/img/armony/planning-mensuel.webp", "alt": "ARMony — planning mensuel : construction du planning des agents avec gestion des effectifs et seuils SMUR" },
+      { "src": "assets/img/armony/secto-1.webp", "alt": "ARMony — écran de sectorisation journalière : répartition des agents par poste avec contrôle des habilitations et alertes de sous-effectif" },
+      { "src": "assets/img/armony/secto-2.webp", "alt": "ARMony — audit d'équité de la sectorisation : nombre de créneaux et taux d'occupation par agent" },
+      { "src": "assets/img/armony/competences-samu-33.webp", "alt": "ARMony — matrice des compétences par poste : niveau d'habilitation de chaque agent pilotant la distribution" },
+      { "src": "assets/img/armony/equite-agents-samu-33-1.webp", "alt": "ARMony — analyse d'équité structurelle : couverture par poste sur l'effectif" },
+      { "src": "assets/img/armony/equite-agents-samu-33-2.webp", "alt": "ARMony — profil de polyvalence de l'équipe et identification des goulets d'étranglement" },
+      { "src": "assets/img/armony/equite-agents-samu-33-3.webp", "alt": "ARMony — équité de charge sur la journée : taux d'occupation et postes tenus par agent" }
+    ],
+    "content": [
+      {
+        "heading": "En bref",
+        "paragraphs": [
+          "Conception et développement d'une suite d'outils d'aide à la planification pour un service de régulation médicale hospitalier (SAMU). De l'analyse du besoin terrain jusqu'au prototype fonctionnel validé par les équipes terrain, en passant par l'extraction et la structuration de données réelles.",
+          "<strong class=\"text-orange\">Compétence illustrée :</strong> outils métier sur mesure, traduire un processus opérationnel complexe en application utilisable, en dialogue direct avec les utilisateurs finaux.",
+          "<strong class=\"text-orange\">Statut :</strong> prototype abouti, en phase de validation institutionnelle."
+        ]
+      },
+      {
+        "heading": "Le contexte",
+        "paragraphs": [
+          "Dans un service de régulation médicale, deux tâches récurrentes mobilisent un temps considérable et reposent largement sur des manipulations manuelles :"
+        ],
+        "bullets": [
+          "<strong class=\"text-orange\">La sectorisation journalière :</strong> répartir chaque jour les agents présents sur les différents postes, en respectant leurs habilitations et les effectifs minimums par poste.",
+          "<strong class=\"text-orange\">La construction du planning mensuel :</strong> bâtir et ajuster le planning de dizaines d'agents sur le mois, en arbitrant les souhaits d'échange tout en garantissant la couverture du service et l'équité."
+        ]
+      },
+      {
+        "heading": "",
+        "paragraphs": [
+          "Ces opérations s'appuyaient sur des supports dispersés (tableurs, documents PDF) et un savoir-faire largement implicite, peu outillé."
+        ]
+      },
+      {
+        "heading": "La démarche",
+        "paragraphs": [
+          "Le cœur du projet n'a pas été uniquement technique. Il a consisté à <strong class=\"text-orange\">comprendre un métier de l'intérieur</strong> et à le traduire en logiciel.",
+          "<strong class=\"text-orange\">Analyse du besoin réel.</strong> Plusieurs hypothèses initiales se sont révélées fausses au contact du terrain. Exemple : on imaginait d'abord un outil qui <em>importe</em> un planning existant ; le dialogue avec les utilisateurs a montré qu'ils voulaient le <em>construire</em> directement dans l'outil. Cette correction a réorienté tout le développement.",
+          "<strong class=\"text-orange\">Structuration de données réelles.</strong> Les plannings du service existaient sous forme de PDF non structurés (dizaines d'agents, codes de vacation, mises en page irrégulières). J'ai développé une chaîne d'extraction pour les transformer en données exploitables, en gérant les cas particuliers (noms multi-mots, codes éclatés sur plusieurs lignes, lignes incomplètes).",
+          "<strong class=\"text-orange\">Co-construction avec les utilisateurs.</strong> Plutôt que d'imposer des règles métier inventées, j'ai conçu des supports de validation (ateliers structurés) permettant aux responsables du service de confirmer ou corriger chaque hypothèse, horaires, seuils d'effectif, habilitations. L'outil distingue clairement ce qui est validé de ce qui reste à confirmer."
+        ]
+      },
+      {
+        "heading": "Ce qui a été livré",
+        "paragraphs": [
+          "<strong class=\"text-orange\">Un outil de sectorisation journalière.</strong> Répartition automatique des agents présents sur les postes, en tenant compte des habilitations et des seuils, avec alertes en cas de sous-effectif sur un poste critique.",
+          "<strong class=\"text-orange\">Un outil de planning mensuel.</strong> Construction et ajustement du planning par glisser-déposer, vue d'ensemble de type tableau, gestion des souhaits d'échange avec détection automatique des conflits et des non-conformités aux règles du service, statut de validation, et persistance du travail.",
+          "<strong class=\"text-orange\">Un pont entre les deux outils.</strong> Le planning mensuel alimente la sectorisation : on choisit un jour, et les agents présents sont reconstruits automatiquement pour être répartis.",
+          "<strong class=\"text-orange\">Des supports de validation métier.</strong> Documents structurés permettant aux responsables de valider les règles et les compétences, conçus pour être remplis sans effort (pré-remplis, à corriger plutôt qu'à saisir)."
+        ]
+      },
+      {
+        "heading": "Aperçu de l'outil",
+        "paragraphs": [ "Quelques écrans du prototype." ],
+        "gallery": true
+      },
+      {
+        "heading": "L'approche technique",
+        "bullets": [
+          "<strong class=\"text-orange\">Front-end sur mesure</strong> en HTML/SVG/JavaScript, sans dépendance lourde : des outils autonomes, ouvrables dans un simple navigateur, sans installation côté utilisateur.",
+          "<strong class=\"text-orange\">Traitement de données</strong> en Python pour l'extraction et la structuration depuis des sources hétérogènes.",
+          "<strong class=\"text-orange\">Persistance locale</strong> et échange de données entre outils par fichiers structurés.",
+          "<strong class=\"text-orange\">Design system cohérent</strong> (palette, typographie, codes couleur accessibles) pour une interface lisible et professionnelle.",
+          "<strong class=\"text-orange\">Versionnement Git</strong> et documentation du projet."
+        ]
+      },
+      {
+        "heading": "",
+        "paragraphs": [
+          "Le choix d'une stack légère est délibéré : pour un prototype destiné à convaincre des décideurs et à être testé en conditions réelles, la simplicité de déploiement prime sur la sophistication technique."
+        ]
+      },
+      {
+        "heading": "Ce que ce projet démontre",
+        "bullets": [
+          "Capacité à <strong class=\"text-orange\">comprendre un métier complexe</strong> et à dialoguer avec des utilisateurs experts non techniciens.",
+          "Capacité à <strong class=\"text-orange\">structurer des données réelles, imparfaites et hétérogènes</strong> en information exploitable.",
+          "Capacité à <strong class=\"text-orange\">concevoir une interface métier</strong> qui colle au geste de travail réel, plutôt qu'à une vision théorique.",
+          "Rigueur sur la <strong class=\"text-orange\">distinction entre hypothèse et donnée validée</strong>, essentiel dans un contexte où une erreur a des conséquences opérationnelles."
+        ]
+      },
+      {
+        "heading": "Pour les structures qui ont un besoin similaire",
+        "paragraphs": [
+          "Beaucoup d'organisations font tourner des processus critiques sur des tableurs bricolés et du savoir-faire implicite. Je conçois des outils métier sur mesure qui captent ce savoir-faire, l'outillent, et le rendent transmissible, en partant du terrain, pas d'un cahier des charges hors-sol."
+        ]
+      }
+    ]
+  },
+  {
     "name": "VIOLETTE CRUSE, DECORATRICE D'INTERIEUR .",
+    "slug": "violette-cruse",
+    "category": "sites-web",
     "year": "2026",
     "project": "Site vitrine pour Violette Cruse, décoratrice d'intérieur à Bordeaux",
     "role": "Zoning, maquettes Figma, intégration de la charte graphique, développement sur-mesure Angular SSR, SEO",
@@ -20,6 +136,8 @@
   },
   {
     "name": "GROUPE ABC IMMOBILIER .",
+    "slug": "groupe-abc-immobilier",
+    "category": "sites-web",
     "year": "2025",
     "project": "Site vitrine pour un réseau national d’experts immobiliers agréés",
     "role": "Zoning, maquettes Figma / Adobe XD, intégration de la charte graphique (Studio Dada), développement sur-mesure Angular SSR, SEO, et déploiement sur VPS",
@@ -35,6 +153,8 @@
   },
   {
     "name": "CB2P AVOCATS .",
+    "slug": "cb2p-avocats",
+    "category": "sites-web",
     "year": "2025",
     "project": "Création du site vitrine pour le cabinet d'avocats CB2P basé à Bordeaux",
     "role": "Design UI, zoning, développement sur mesure, responsive, SEO, déploiement",
@@ -52,6 +172,8 @@
   },
   {
     "name": "LAITERIE BURDIGALA .",
+    "slug": "laiterie-burdigala",
+    "category": "sites-web",
     "year": "2025",
     "project": "Creation du site internet de la Laiterie Burdigala aux Capucins - Bordeaux",
     "role": "Charte graphique, ergonomie, zoning, design et developpement, Click&collect sur mesure, SEO, deploiement",
@@ -81,6 +203,8 @@
   },
   {
     "name": "ANGLAIS DU VIN .",
+    "slug": "anglais-du-vin",
+    "category": "sites-web",
     "year": "2024",
     "project": "Creation d'un site internet pour un manuel d'anglais destine aux professionnels du vin",
     "role": "Charte graphique, ergonomie, zoning, design et developpement, SEO, deploiement",
@@ -105,6 +229,8 @@
   },
   {
     "name": "L'IMAGO REFLEXO .",
+    "slug": "imago-reflexo",
+    "category": "sites-web",
     "year": "2024",
     "project": "Creation du site internet de L'imago Reflexo - Reflexologie plantaire et palmaire",
     "role": "Creation logo, charte graphique, ergonomie, zoning, design et developpement, SEO, deploiement",
@@ -131,6 +257,8 @@
   },
   {
     "name": "MAISON AH-RONG .",
+    "slug": "maison-ah-rong",
+    "category": "sites-web",
     "year": "2024",
     "project": "Creation du site internet pour un institut de massages coreens - Bordeaux",
     "role": "Charte graphique, ergonomie, zoning, design et developpement, SEO, deploiement",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
…, migration ARMony, 301

Système unifié de pages projet alimenté par un projects.json enrichi :

- data: ajout slug + category sur chaque projet, interface Project mise à jour ; ARMony enrichi (content riche structuré, galleryImages, seo) ; resolveJsonModule activé.
- détail générique SSR /projets/:category/:slug (ProjetDetailComponent) via import JSON synchrone, sans garde isPlatformBrowser ; bouton "Voir le site" / "Prendre rendez-vous" selon présence d'url ; OG via SeoService (type/ogTitle ajoutés).
- migration ARMony dans le système générique (contenu repris mot pour mot) ; page dédiée armony.component supprimée.
- redirection 301 Express /projets/armony -> /projets/outils-metier/armony (server.ts).
- listes par catégorie /projets/:category (ProjetsListeComponent) en SSR.
- liens "Mes projets" sur /outils-metier et /sites-web ; section "Étude de cas" ARMony dans /outils-metier ; carte ARMony cliquable (internalRoute) dans la galerie home.
- contact: entrée "Réserver un créneau" (Google Calendar).
- UI: galerie home, wrap titres (année insécable), agencement CTA hero, espacement bouton détail ; entrée Violette Cruse dans "Projets récents" (sites-web).

Note: images src/assets/img/armony/ gitignorées, déployées par SCP.